### PR TITLE
Fix error with large charges

### DIFF
--- a/goodvibes/GoodVibes.py
+++ b/goodvibes/GoodVibes.py
@@ -335,7 +335,7 @@ class calc_bbe:
          if line.strip().find("Energy= ") > -1 and line.strip().find("Predicted")==-1 and line.strip().find("Thermal")==-1: self.scf_energy = (float(line.strip().split()[1]))
          # look for thermal corrections, paying attention to point group symmetry
          if line.strip().startswith('Zero-point correction='): self.zero_point_corr = float(line.strip().split()[2])
-         if line.strip().find('Multiplicity') > -1: mult = float(line.strip().split()[5])
+         if line.strip().find('Multiplicity') > -1: mult = float(line.split('=')[-1].strip())
          if line.strip().startswith('Molecular mass:'): molecular_mass = float(line.strip().split()[2])
          if line.strip().startswith('Rotational symmetry number'): symmno = int((line.strip().split()[3]).split(".")[0])
          if line.strip().startswith('Full point group'):


### PR DESCRIPTION
The Gaussian parser fails if one file has large charge (say, `-11`). In those cases, the Gaussian output does not feature a space between the `=` and the `<charge>` value:

```
 Charge =-11 Multiplicity = 1
```

As a result one less field is obtained after the `.split()` method on the line, resulting in an `IndexError` when accessing the multiplicity value at line 338. This PR provides an alternative way of obtaining the multiplicity, splitting by `=` first, instead of blanks.

