### PR TITLE
Fix reading of multiplicities >= 10

### DIFF
--- a/goodvibes/GoodVibes.py
+++ b/goodvibes/GoodVibes.py
@@ -1432,8 +1432,8 @@ def parse_data(file):
                     repeated_link1 = 1
                 version_program = version_program[1:]
             if "Charge" in line.strip() and "Multiplicity" in line.strip():
-                charge = line.strip("=").split()[2]
-                multiplicity = line.strip('=').split()[5]
+                charge = line.split('Multiplicity')[0].split('=')[-1].strip()
+                multiplicity = line.split('=')[-1].strip()
         if program == "Orca":
             if line.strip().startswith('FINAL SINGLE POINT ENERGY'):
                 spe = float(line.strip().split()[4])


### PR DESCRIPTION
This address #29. If multiplicity >= 10, then there is no space between the = sign and multiplicity (e.g.  Charge =  0 Multiplicity =15), which led to an I/O error. Now fixed.