### PR TITLE
create entry_point for goodvibes during installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,9 @@ setup(
   install_requires=["numpy", ],
   python_requires='>=2.6',
   include_package_data=True,
+  entry_points={
+    'console_scripts': [
+        'goodvibes = goodvibes.GoodVibes:main',
+    ],
+  }
 )


### PR DESCRIPTION
Small PR to add an entry_point during installation.
This essentially would allow users to run `goodvibes -h` to achieve the same thing as previously done by `python -m goodvibes -h` 