### PR TITLE
Replace custom output file parsing with cclib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
       install:
         - ./.travis-install.sh
         - pip install pytest
+        - pip install --upgrade numpy
         - python -m pip install .
       script:
         - pytest -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       install:
         - ./.travis-install.sh
         - pip install pytest
-        - python setup.py install
+        - python -m pip install .
       script:
         - pytest -v
     - os: linux
@@ -19,7 +19,7 @@ matrix:
       install:
         - ./.travis-install.sh
         - pip install pytest
-        - python setup.py install
+        - python -m pip install .
       script:
         - pytest -v
     - os: linux
@@ -29,7 +29,7 @@ matrix:
       install:
         - ./.travis-install.sh
         - pip install pytest
-        - python setup.py install
+        - python -m pip install .
       script:
         - pytest -v
     - os: linux
@@ -39,7 +39,7 @@ matrix:
       install:
         - ./.travis-install.sh
         - pip install pytest
-        - python setup.py install
+        - python -m pip install .
       script:
         - pytest -v
     - os: osx
@@ -48,7 +48,7 @@ matrix:
       install:
         - ./.travis-install.sh
         - pip3 install pytest
-        - python3 setup.py install
+        - python3 -m pip install .
       script:
         - pytest -v
     - os: osx
@@ -58,7 +58,7 @@ matrix:
       install:
         - ./.travis-install.sh
         - pip3 install pytest
-        - python3 setup.py install
+        - python3 -m pip install .
       script:
         - pytest -v
     - os: osx
@@ -68,7 +68,7 @@ matrix:
       install:
         - ./.travis-install.sh
         - pip3 install pytest
-        - python3 setup.py install
+        - python3 -m pip install .
       script:
         - pytest -v
     - os: windows
@@ -85,7 +85,7 @@ matrix:
       install:
         - ./.travis-install.sh
         - pip install pytest
-        - python setup.py install
+        - python -m pip install .
       script:
         - pytest -v
     - os: windows
@@ -102,7 +102,7 @@ matrix:
       install:
         - ./.travis-install.sh
         - pip install pytest
-        - python setup.py install
+        - python -m pip install .
       script:
         - pytest -v
     - os: windows
@@ -119,6 +119,6 @@ matrix:
       install:
         - ./.travis-install.sh
         - pip install pytest
-        - python setup.py install
+        - python -m pip install .
       script:
         - pytest -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,8 @@ matrix:
         - python -m pip install --upgrade pip
         - pip install --upgrade pytest
         - pip install codecov
+        - pip install numpy
         - pip install cython
-        - pip install numpy==1.17.4
       env: PATH=/c/Python36:/c/Python36/Scripts:$PATH
       install:
         - ./.travis-install.sh
@@ -96,6 +96,7 @@ matrix:
         - python -m pip install --upgrade pip
         - pip install --upgrade pytest
         - pip install codecov
+        - pip install numpy
         - pip install cython
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
       install:
@@ -112,6 +113,7 @@ matrix:
         - python -m pip install --upgrade pip
         - pip install --upgrade pytest
         - pip install codecov
+        - pip install numpy
         - pip install cython
       env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
       install:

--- a/goodvibes/io.py
+++ b/goodvibes/io.py
@@ -723,18 +723,17 @@ def read_initial(file):
 
     return level_of_theory, solvation_model, progress, orientation, dft_used
 
-def jobtype(file):
-    """Read output for the level of theory and basis set used."""
-    with open(file) as f:
-        data = f.readlines()
+def gaussian_jobtype(filename):
+    """Read the jobtype from a Gaussian archive string."""
     job = ''
-    for line in data:
-        if line.strip().find('\\SP\\') > -1:
-            job += 'SP'
-        if line.strip().find('\\FOpt\\') > -1:
-            job += 'GS'
-        if line.strip().find('\\FTS\\') > -1:
-            job += 'TS'
-        if line.strip().find('\\Freq\\') > -1:
-            job += 'Freq'
+    with open(filename) as f:
+        for line in f:
+            if line.strip().find('\\SP\\') > -1:
+                job += 'SP'
+            if line.strip().find('\\FOpt\\') > -1:
+                job += 'GS'
+            if line.strip().find('\\FTS\\') > -1:
+                job += 'TS'
+            if line.strip().find('\\Freq\\') > -1:
+                job += 'Freq'
     return job

--- a/goodvibes/thermo.py
+++ b/goodvibes/thermo.py
@@ -407,7 +407,7 @@ class calc_bbe:
             fract_modelsys = []
             freq_scale_factor = [freq_scale_factor, mm_freq_scale_factor]
         self.xyz = getoutData(file)
-        self.job_type = jobtype(file)
+        self.job_type = gaussian_jobtype(file)
         self.roconst = []
         # Parse some useful information from the file
         self.sp_energy, self.program, self.version_program, self.solvation_model, self.file, self.charge, self.empirical_dispersion, self.multiplicity = parse_data(

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
   download_url='https://github.com/bobbypaton/GoodVibes/archive/v3.0.1.zip',
   keywords=['compchem', 'thermochemistry', 'gaussian', 'vibrational-entropies', 'temperature'],
   classifiers=[],
-  install_requires=["numpy", ],
+  install_requires=["cclib", "numpy"],
   python_requires='>=2.6',
   include_package_data=True,
   entry_points={

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
   download_url='https://github.com/bobbypaton/GoodVibes/archive/v3.0.1.zip',
   keywords=['compchem', 'thermochemistry', 'gaussian', 'vibrational-entropies', 'temperature'],
   classifiers=[],
-  install_requires=["cclib", "numpy"],
+  install_requires=["cclib"],
   python_requires='>=2.6',
   include_package_data=True,
   entry_points={

--- a/tests/test_goodvibes.py
+++ b/tests/test_goodvibes.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os
 import pytest
 import math
 from goodvibes import GoodVibes as GV


### PR DESCRIPTION
This is a proposal to replace much (but not all) of the custom output parsing with cclib, so that GoodVibes can be used with any computational chemistry program that cclib supports, and not just Gaussian, ORCA, and NWChem.

It can't be a complete replacement because:
- cclib doesn't yet parse any information about solvation methods (I think you just want the name?),
- cclib doesn't yet parse timing information (though it is currently in progress),
- cclib doesn't detect all job types (specifically TS), and
- basis set and method information from cclib is spotty.

cclib also can't read COSMO-RS files, but since that's for a completely separate quantity, I won't consider in this PR.

cclib parses version information well, but I haven't investigated yet what GoodVibes is parsing as versions, hence the current draft status.

If you're ok with an extra dependency, let me know your thoughts. There may also be a version restriction, since cclib now has a minimum required Python version of 3.5 (2.7 may still work, but is no longer tested, and 2.6 definitely doesn't work).