### PR TITLE
include a basic parser for Orca thermochemistry data

### DIFF
--- a/goodvibes/thermo.py
+++ b/goodvibes/thermo.py
@@ -581,7 +581,7 @@ class calc_bbe:
                     msecs = int(float(line.split()[9]) * 1000.0) + self.cpu[4]
                     self.cpu = [days, hours, mins, secs, msecs]
 
-        if self.sp_program == 'NWChem' or self.program == 'NWChem':
+        elif self.sp_program == 'NWChem' or self.program == 'NWChem':
             # Iterate
             for i,line in enumerate(g_output):
                 #scanning for low frequencies...
@@ -650,7 +650,7 @@ class calc_bbe:
                     msecs = 0
                     self.cpu = [days,hours,mins,secs,msecs]
         
-        if self.sp_program == 'Orca' or self.program == 'Orca':
+        elif self.sp_program == 'Orca' or self.program == 'Orca':
             import re
             # scan and parse all frequencies wavenumbers
             for i,line in enumerate(g_output):


### PR DESCRIPTION
I have written a parser for Orca 5.0.4 thermochemistry data (thermo.py file) based on the implementation available for the NWChem. I didn't fully understand the symmetry portion of the code, so I let this part half-implemented (Recover the symmetry number and point group from the output, but I didn't assign a value to `symno` or `linear_mol`.) . Also, I didn't find a "Rotational temperature" in the Orca output, as it is available in Gaussian 16 calculations. With some help, I can finish this implementation and fully test it. 
Also, I use a loop per property. This is somewhat different from the current implementation (a single loop and parsing the properties as you go) and I have employed regular expressions too. If necessary, I can refactor this code to comply with the structure used in Gaussian and NWChem parsers.
