### PR TITLE
Echo command line into the .dat output (#103)

### DIFF
--- a/goodvibes/GoodVibes.py
+++ b/goodvibes/GoodVibes.py
@@ -30,6 +30,10 @@ from .output import (print_results, print_temperature_interval,
 
 log = logging.getLogger('goodvibes')
 
+# Above this many input files, the command echo collapses the file list to a
+# "<N files>" placeholder instead of listing every path.
+COMMAND_ECHO_FILE_LIMIT = 10
+
 
 def parse_arguments():
     """Parse command-line arguments and return (options, args)."""
@@ -218,22 +222,23 @@ def parse_arguments():
     elif options.invert is not None and options.invert > 0:
         options.invert = -1 * options.invert
 
-    # Build the command echo from the original CLI invocation.
-    # File-path positional args (often dozens of .log/.out files) are
-    # collapsed to a "<N files>" placeholder so the line stays readable.
+    # Build the command echo from the original CLI invocation so it can be
+    # logged to the .dat file (users copy/paste it to reproduce runs).
+    # File-path positional args are kept verbatim when there are only a few,
+    # but collapsed to a "<N files>" placeholder past a threshold so the line
+    # stays readable for runs over dozens of .log/.out files.
     file_args, flag_args = [], []
     for arg in sys.argv[1:]:
         if os.path.splitext(arg)[1].lower() in SUPPORTED_EXTENSIONS:
             file_args.append(arg)
         else:
             flag_args.append(arg)
-    file_summary = f'<{len(file_args)} file{"" if len(file_args) == 1 else "s"}>' if file_args else ''
-    parts = ['o  Requested: goodvibes']
-    if file_summary:
-        parts.append(file_summary)
-    parts.extend(flag_args)
-    command = ' '.join(parts)
-    print(command)
+    if len(file_args) > COMMAND_ECHO_FILE_LIMIT:
+        file_parts = [f'<{len(file_args)} files>']
+    else:
+        file_parts = file_args
+    parts = ['o  Requested: goodvibes', *file_parts, *flag_args]
+    options.command = ' '.join(parts)
 
     # Collect filenames from the unrecognized positional arguments
     files = []
@@ -491,6 +496,10 @@ def main():
     # Print banner
     log.info(gv_banner)
 
+    # Echo the command line into stdout *and* the .dat file so the run is
+    # self-documenting and reproducible (issue #103).
+    log.info(getattr(options, 'command', 'o  Requested: goodvibes'))
+
     # Fail fast on unknown solvent names — let the user fix the typo before we
     # parse a thousand files.
     if options.media is not None:
@@ -567,7 +576,6 @@ def main():
     if not files:
         sys.exit("\n!  Specify at least one output files on the command line ¯\\_(ツ)_/¯ \n")
 
-    # log.info('\n' + command + '\n')
     if options.temperature_interval is None:
         log.info(f"   Temperature = {options.temperature} Kelvin")
 

--- a/goodvibes/GoodVibes.py
+++ b/goodvibes/GoodVibes.py
@@ -233,8 +233,19 @@ def parse_arguments():
     # (flags and their values) is preserved in order so the echo stays
     # copy/paste-able.
     file_args = [a for a in args if os.path.splitext(a)[1].lower() in SUPPORTED_EXTENSIONS]
-    file_set = set(file_args)
-    flag_args = [a for a in sys.argv[1:] if a not in file_set]
+
+    # Remove positional file args from argv so they are not echoed twice. Do this
+    # by occurrence (right-to-left) so option values that happen to match a file
+    # name are less likely to be dropped.
+    from collections import Counter
+    to_remove = Counter(file_args)
+    flag_args = []
+    for tok in reversed(sys.argv[1:]):
+        if to_remove.get(tok, 0) > 0:
+            to_remove[tok] -= 1
+            continue
+        flag_args.append(tok)
+    flag_args.reverse()
     if len(file_args) > COMMAND_ECHO_FILE_LIMIT:
         file_parts = [f'<{len(file_args)} files>']
     else:

--- a/goodvibes/GoodVibes.py
+++ b/goodvibes/GoodVibes.py
@@ -224,15 +224,17 @@ def parse_arguments():
 
     # Build the command echo from the original CLI invocation so it can be
     # logged to the .dat file (users copy/paste it to reproduce runs).
-    # File-path positional args are kept verbatim when there are only a few,
-    # but collapsed to a "<N files>" placeholder past a threshold so the line
-    # stays readable for runs over dozens of .log/.out files.
-    file_args, flag_args = [], []
-    for arg in sys.argv[1:]:
-        if os.path.splitext(arg)[1].lower() in SUPPORTED_EXTENSIONS:
-            file_args.append(arg)
-        else:
-            flag_args.append(arg)
+    # parse_known_args() has already consumed option *values* (e.g. the pattern
+    # for --exclude) into `options`, leaving only positional inputs in `args`;
+    # those — not a blind extension scan of sys.argv — are the true file
+    # arguments. Positionals are kept verbatim when there are only a few, but
+    # collapsed to a "<N files>" placeholder past a threshold so the line stays
+    # readable for runs over dozens of .log/.out files. Everything else in argv
+    # (flags and their values) is preserved in order so the echo stays
+    # copy/paste-able.
+    file_args = [a for a in args if os.path.splitext(a)[1].lower() in SUPPORTED_EXTENSIONS]
+    file_set = set(file_args)
+    flag_args = [a for a in sys.argv[1:] if a not in file_set]
     if len(file_args) > COMMAND_ECHO_FILE_LIMIT:
         file_parts = [f'<{len(file_args)} files>']
     else:


### PR DESCRIPTION
Fixes #103.

## Problem

In v4.3 the command line is no longer included at the top of the `.dat` output (it was in v3). The `o  Requested: goodvibes ...` echo was only sent to **stdout** via `print()`, and it ran inside `parse_arguments()` — *before* `setup_logging()` attaches the logger's `.dat` file handler in `main()`. So even though it printed to the terminal, it never reached the `.dat` file, and users could no longer copy/paste it to reproduce a run.

A leftover dead `# log.info('\n' + command + '\n')` line confirmed this used to be logged.

## Fix

- Build the echo in `parse_arguments()` and store it on `options.command`.
- Re-emit it via `log.info()` immediately after the banner in `main()`, so it lands in **both** stdout and the `.dat` file.
- Remove the dead commented-out log line.

## File-list collapsing

The issue also asks for the fuller command. The echo now shows the file list **verbatim** for small runs (≤ 10 files) so it's directly copy/paste-able, and collapses to `<N files>` above that threshold (new `COMMAND_ECHO_FILE_LIMIT` constant) to keep the line readable for large batches. Previously it *always* collapsed regardless of count.

The echo keeps the installed `goodvibes` entry-point name (the actual reproducible invocation) rather than `python -m goodvibes`.

## Verification

- 2 files → `o  Requested: goodvibes .../01a_water_hf_freq.log .../01b_water_hf_freq_scaled.log -c 1 -t 300`
- 54 files → `o  Requested: goodvibes <54 files> -t 300`
- Line now appears in both stdout and the `.dat` file.
- `tests/test_cli_examples.py`: 35 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command echoing to produce a deterministic, reproducible command summary for run history.
  * When many input files are provided, the echoed command now shortens the file list (using a placeholder) for better readability.
  * Command options are displayed in a more stable order, with file paths grouped separately from other flags, and logged consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->