### PR TITLE
Fix table cropping at 80 cols on dumb terminals (CircleCI)

### DIFF
--- a/goodvibes/output.py
+++ b/goodvibes/output.py
@@ -360,6 +360,8 @@ def _print_rich_table(table: "Table") -> None:
             force_terminal=console.is_terminal,
             color_system=console.color_system,
             width=console.width,
+            height=console.height,  # without height, this render console
+                                    # re-clamps width to 80 on dumb terminals
         ).print(table)
         text = buf.getvalue().rstrip("\n")
         lines = text.split("\n")

--- a/goodvibes/utils.py
+++ b/goodvibes/utils.py
@@ -75,7 +75,13 @@ def setup_logging(filein, append):
     logger.addHandler(console_handler)
 
     if Console is not None:
-        _console_stdout = Console(highlight=False, force_terminal=True, width=200)
+        # height MUST be set alongside width: Rich's Console.size only
+        # short-circuits to the explicit width when height is also given.
+        # With only width set, a dumb terminal (TERM=dumb, e.g. CircleCI)
+        # runs terminal detection, ignores width=200 and clamps to 80 cols,
+        # cropping the rightmost table columns (incl. qh-G).
+        _console_stdout = Console(highlight=False, force_terminal=True,
+                                  width=200, height=200)
 
     # .dat file: shared handle for both logging and Rich output
     dat_path = f'{filein}_{append}.dat'
@@ -96,6 +102,8 @@ def setup_logging(filein, append):
             width=200,            # match stdout console: Rich defaults non-TTY
                                   # files to 80 cols and crops tables, dropping
                                   # the rightmost columns (incl. qh-G) from .dat
+            height=200,           # required for width to be honored on dumb
+                                  # terminals (see _console_stdout above)
         )
 
 


### PR DESCRIPTION
## Problem

CircleCI runs with `TERM=dumb` (its Docker image), where Rich silently clamps console width to 80 columns and crops the rightmost table columns — including `qh-G(T)` and `Boltz` — from both stdout and the `.dat` archive. This surfaced as two failures on `main` after the v4.3.0 work merged:

```
FAILED tests/test_cli_errors.py::TestMainDirect::test_default_run_writes_dat_with_structure_row
       - AssertionError: assert 'qh-G(T)' in '...'   (table cropped at 80 cols)
FAILED tests/test_cli_errors.py::TestMainDirect::test_boltz_populations
       - AssertionError: assert 'Boltz' in '...'
```

The local `git` test runs pass because a real terminal reports its true width; only `TERM=dumb` triggers the crop.

## Root cause

Rich's `Console.size` only short-circuits to an explicit `width` when `height` is **also** set. With `width=200` alone:

```python
Console(file=buf, force_terminal=True, width=200)        # TERM=dumb -> width=80  (crops)
Console(file=buf, force_terminal=True, width=200, height=200)  # TERM=dumb -> width=200 (ok)
```

## Fix

Set `height` alongside `width` on all three `Console` instances:
- the two module-level consoles in `setup_logging()` (`_console_stdout`, `_console_dat`);
- the per-table render console in `output._print_rich_table` — it inherits `width` from the outer console but, without its own `height`, re-clamps to 80.

## Verification

- Reproduced locally with `TERM=dumb`: 80-col header, `qh-G(T)` absent.
- After fix: 112-col header, all columns present.
- **Full suite under `TERM=dumb`: 2493 passed**, including the two regression tests that were failing on CircleCI. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table and log rendering on basic terminals so output displays with the intended width more consistently.
  * Reduced unwanted re-wrapping or clamping behavior when viewing rich output in terminal environments with limited display capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->