### PR TITLE
chore: sync uv.lock with pymsym Windows marker

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -710,7 +710,7 @@ dependencies = [
     { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pymsym" },
+    { name = "pymsym", marker = "sys_platform != 'win32'" },
     { name = "rich" },
 ]
 
@@ -762,7 +762,7 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'test'" },
     { name = "pyarrow", marker = "extra == 'full'" },
     { name = "pyarrow", marker = "extra == 'test'" },
-    { name = "pymsym" },
+    { name = "pymsym", marker = "sys_platform != 'win32'" },
     { name = "pytest", marker = "extra == 'test'" },
     { name = "pytest-cov", marker = "extra == 'test'" },
     { name = "pyyaml", marker = "extra == 'full'" },


### PR DESCRIPTION
`pyproject.toml` gates `pymsym` on non-Windows platforms (issue #102: `pymsym; platform_system != 'Windows'`), but `uv.lock` still pinned it unconditionally. Regenerated with `uv lock` so the lock matches the manifest.

Two-line change; no runtime or CI impact (CI installs via pip) — purely lockfile consistency for `uv` users.