### PR TITLE
Bump version to 4.4.0

### DIFF
--- a/goodvibes/constants.py
+++ b/goodvibes/constants.py
@@ -1,7 +1,7 @@
 """Constants and literature references for GoodVibes."""
 
 # VERSION NUMBER
-__version__ = "4.3.0"
+__version__ = "4.4.0"
 
 SUPPORTED_EXTENSIONS = set(('.out', '.log', '.extxyz'))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "goodvibes"
-version = "4.3.0"
+version = "4.4.0"
 description = "A python program to compute corrections to thermochemical data from frequency calculations"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Version bump for the release carrying #109 (the `parse_hessian()` API, `QCData.per_atom_masses`, the `parse_data` route-section fix, and basis-set spelling canonicalization).

Bumps `4.3.0 -> 4.4.0` in `pyproject.toml` and `goodvibes/constants.py`. No functional changes.

Motivation: Kinisot 2.1.0 pins `goodvibes >= 4.4`, so a tagged 4.4.0 release on PyPI is what unblocks the Kinisot side. After merging, tag `v4.4.0` and publish to PyPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app/package version to **4.4.0**.
  * The displayed version information in the app banner now reflects the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->