### PR TITLE
Fix TypeError in check_files SPC level-of-theory validation

### DIFF
--- a/goodvibes/validation.py
+++ b/goodvibes/validation.py
@@ -330,10 +330,14 @@ def check_files(thermo_data, options, level_of_theory):
         # Check SPC level of theory (the `level_of_theory` parameter holds the
         # freq-level strings, so the SPC files are re-read via io.level_of_theory)
         l_o_t_spc = [read_level_of_theory(name) for name in names_spc]
-        if all_same(l_o_t_spc):
-            log.info("\no  Using {} in all the single-point corrections.".format(l_o_t_spc[0]))
+        if len(names_spc) == len(files):
+            if all_same(l_o_t_spc):
+                log.info("\no  Using {} in all the single-point corrections.".format(l_o_t_spc[0]))
+            else:
+                print_check_fails(l_o_t_spc, names_spc, "levels of theory")
         else:
-            print_check_fails(l_o_t_spc, names_spc, "levels of theory")
+            log.info("\n   x One or more single-point correction files are missing; "
+                     "unable to check levels of theory.")
 
         # Check SPC charge and multiplicity
         charge_spc_check = [thermo_data[key].sp_charge for key in thermo_data]

--- a/goodvibes/validation.py
+++ b/goodvibes/validation.py
@@ -6,6 +6,7 @@ import sys
 from .sort import deduplicate
 from .utils import all_same
 from .io import parse_qcdata, read_initial, find_spc_file
+from .io import level_of_theory as read_level_of_theory
 
 log = logging.getLogger('goodvibes')
 
@@ -326,12 +327,13 @@ def check_files(thermo_data, options, level_of_theory):
         else:
             print_check_fails(spc_solvent_check, file_check, "solvation models")
 
-        # Check SPC level of theory
-        l_o_t_spc = [level_of_theory(name) for name in names_spc]
+        # Check SPC level of theory (the `level_of_theory` parameter holds the
+        # freq-level strings, so the SPC files are re-read via io.level_of_theory)
+        l_o_t_spc = [read_level_of_theory(name) for name in names_spc]
         if all_same(l_o_t_spc):
             log.info("\no  Using {} in all the single-point corrections.".format(l_o_t_spc[0]))
         else:
-            print_check_fails(l_o_t_spc, file_check, "levels of theory")
+            print_check_fails(l_o_t_spc, names_spc, "levels of theory")
 
         # Check SPC charge and multiplicity
         charge_spc_check = [thermo_data[key].sp_charge for key in thermo_data]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -21,8 +21,8 @@ from goodvibes.validation import (
     print_check_fails,
     check_files,
 )
-from goodvibes.thermo import calc_bbe
-from conftest import g16path
+from goodvibes.thermo import calc_bbe, ThermoOptions
+from conftest import g16path, datapath
 
 
 GAS_CONSTANT = 8.3144621
@@ -230,6 +230,20 @@ def test_check_files_runs_with_duplicate_option(caplog):
     with caplog.at_level(logging.INFO, logger='goodvibes'):
         check_files(data, _opts(duplicate=True), lots)
     assert 'No duplicates' in caplog.text
+
+
+def test_check_files_spc_reads_spc_level_of_theory(caplog):
+    """--check with --spc re-reads each SPC file's level of theory instead of
+    calling the level_of_theory list as a function (issue #111 regression)."""
+    path = datapath('ethane.out')
+    data = {path: calc_bbe.from_options(path, ThermoOptions(spc='TZ'))}
+    lots = ['B3LYP/6-31G(d)']
+    with caplog.at_level(logging.INFO, logger='goodvibes'):
+        check_files(data, _opts(spc='TZ'), lots)
+    text = caplog.text
+    assert 'Checks for single-point corrections' in text
+    # The SPC level of theory comes from ethane_TZ.out, not the freq file
+    assert 'Using B3LYP/6-311G(d,p) in all the single-point corrections' in text
 
 
 def test_check_files_dispersion_homogeneous(caplog):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -246,6 +246,19 @@ def test_check_files_spc_reads_spc_level_of_theory(caplog):
     assert 'Using B3LYP/6-311G(d,p) in all the single-point corrections' in text
 
 
+def test_check_files_spc_missing_file_reports_caution(caplog):
+    """--check with --spc reports missing SPC files instead of crashing with
+    an IndexError on an empty level-of-theory list."""
+    path = datapath('ethane.out')
+    data = {path: calc_bbe.from_options(path, ThermoOptions(spc='TZ'))}
+    lots = ['B3LYP/6-31G(d)']
+    with caplog.at_level(logging.INFO, logger='goodvibes'):
+        # No ethane_BOGUS.{log,out} exists, so no SPC files are found
+        check_files(data, _opts(spc='BOGUS'), lots)
+    text = caplog.text
+    assert 'unable to check levels of theory' in text
+
+
 def test_check_files_dispersion_homogeneous(caplog):
     """When every file reports 'No empirical dispersion detected', the
     summary line uses the '-' (informational) marker, not 'x' (caution)."""


### PR DESCRIPTION
Fixes #111

## Problem

Combining `--check` with `--spc <suffix>` crashed:

```
File "goodvibes/validation.py", line 330, in check_files
    l_o_t_spc = [level_of_theory(name) for name in names_spc]
TypeError: 'list' object is not callable
```

`check_files()` takes `level_of_theory` as a **list** of per-file strings, but the SPC-validation branch still contained a call from before the refactor, when `io.level_of_theory` (a file parser) was imported at module level. The list parameter shadowed the function name. Not Windows-specific — reproduces on any platform.

## Fix

- Import the parser as `read_level_of_theory` (aliased so the parameter no longer shadows it) and use it to read each SPC file's level of theory — the correct behavior, since the parameter only holds the freq-level strings.
- On the mismatch path, pass `names_spc` (the SPC filenames) to `print_check_fails` instead of the parent filenames, so groups are attributed correctly when an SPC file is missing.

## Testing

- Reproduced the crash with `goodvibes ethane.out --spc TZ --check`; after the fix the run completes and reports `Using B3LYP/6-311G(d,p) in all the single-point corrections` (the TZ single-point level, distinct from the B3LYP/6-31G(d) freq level).
- Added regression test `test_check_files_spc_reads_spc_level_of_theory`.
- Full suite: 2512 passed; ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected single-point correction validation so the level of theory is derived from the single-point (SPC) data files.
  * Improved mismatch reporting to reference the relevant SPC files when discrepancies are detected.
  * When SPC files are missing, the validation now logs a caution instead of failing the “levels of theory” check.
* **Tests**
  * Added regression coverage for SPC level-of-theory reading and for missing-SPC handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->